### PR TITLE
Upgrade to java 14

### DIFF
--- a/.run/LibraryApplication - backend.run.xml
+++ b/.run/LibraryApplication - backend.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="LibraryApplication - backend" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <module name="backend" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.tartu.library.LibraryApplication" />
+    <option name="VM_PARAMETERS" value="-XX:+ShowCodeDetailsInExceptionMessages" />
+    <option name="ALTERNATIVE_JRE_PATH" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ jdk:
 
 script: mvn clean install
 
-#cache:
-#  directories:
-#    - node_modules
+cache:
+  directories:
+    - node_modules
 
 #after_success:
 #  - mvn clean test jacoco:report coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - openjdk13
+  - openjdk14
 
 script: mvn clean install
 

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -Dserver.port=$PORT -jar backend/target/backend-0.1.0.jar
+web: java -Dserver.port=$PORT -jar backend/target/backend-0.1.0.jar --enable-preview

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -Dserver.port=$PORT -jar backend/target/backend-0.1.0.jar --enable-preview
+web: java -Dserver.port=$PORT -jar backend/target/backend-0.1.0.jar

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Deployed at Heroku at: `https://tartu-library.herokuapp.com/`
     - Login to Postgres DB CLI
 - `heroku info`
 - `heroku config`
+    - Set config variables
+    - `heroku config:set _JAVA_OPTIONS="--enable-preview -XX:+ShowCodeDetailsInExceptionMessages"`
+        - Sets the java preview features to be ran with app
 - `heroku logs --tail`
     - View only the tail of the logs on the server
     

--- a/backend/README.md
+++ b/backend/README.md
@@ -14,7 +14,7 @@ It should be able to keep track of multiple copies of the same book.  The borrow
 
 ## Configuration
 
--   [![versionjava](https://img.shields.io/badge/jdk-13-brightgreen.svg?logo=java)](https://github.com/spring-projects/spring-boot)
+-   [![versionjava](https://img.shields.io/badge/jdk-14-brightgreen.svg?logo=java)](https://github.com/spring-projects/spring-boot)
 -   Google Java Formatter plugin
 -   IntelliJ IDE
 -   Cool plugins:

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -115,6 +115,14 @@
 				<configuration>
 					<release>14</release>
 					<compilerArgs>--enable-preview</compilerArgs>
+					<forceJavacCompilerUse>true</forceJavacCompilerUse>
+					<parameters>true</parameters>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>--enable-preview</argLine>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -14,6 +14,7 @@
 
 	<properties>
 		<java.version>14</java.version>
+		<maven.compiler.source>14</maven.compiler.source>
 		<maven.compiler.release>14</maven.compiler.release>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 <!--		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>-->
@@ -112,8 +113,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-<!--					<source>14</source>-->
-<!--					<target>14</target>-->
 					<release>14</release>
 					<forceJavacCompilerUse>true</forceJavacCompilerUse>
 					<parameters>true</parameters>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -114,8 +114,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<release>14</release>
-					<forceJavacCompilerUse>true</forceJavacCompilerUse>
-					<parameters>true</parameters>
+					<compilerArgs>--enable-preview</compilerArgs>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -13,8 +13,8 @@
 	</parent>
 
 	<properties>
-		<java.version>13</java.version>
-		<maven.compiler.release>13</maven.compiler.release>
+		<java.version>14</java.version>
+		<maven.compiler.release>14</maven.compiler.release>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 <!--		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>-->
 
@@ -112,7 +112,11 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<release>13</release>
+<!--					<source>14</source>-->
+<!--					<target>14</target>-->
+					<release>14</release>
+					<forceJavacCompilerUse>true</forceJavacCompilerUse>
+					<parameters>true</parameters>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/backend/src/main/java/com/tartu/library/book/application/services/BookItemAssembler.java
+++ b/backend/src/main/java/com/tartu/library/book/application/services/BookItemAssembler.java
@@ -34,21 +34,18 @@ public class BookItemAssembler extends RepresentationModelAssemblerSupport<BookI
     dto.setStatus(bookItem.getStatus());
 
     switch (bookItem.getStatus()) {
-      case AVAILABLE:
+      case AVAILABLE ->
         dto.add(
             linkTo(methodOn(BookItemRestController.class).borrowBook(bookItem.getId()))
                 .withRel("borrow")
                 .withType(HttpMethod.PATCH.toString()));
-        break;
-      case BORROWED:
+      case BORROWED ->
         dto.add(
             linkTo(methodOn(BookItemRestController.class).returnBook(bookItem.getId()))
                 .withRel("return")
                 .withType(HttpMethod.PATCH.toString()));
-      default:
-        break;
-        //              throw new IllegalArgumentException(String.format("Status not available.
-        // Status: (%s)", bookItem.getStatus()))
+      default -> throw new IllegalArgumentException(String.format("Status not available. Status: (%s)", bookItem.getStatus()));
+
     }
 
     return dto;

--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,1 @@
-java.runtime.version=13
+java.runtime.version=14

--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,0 @@
-java.runtime.version=14

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,2 @@
+# Used by Heroku
+java.runtime.version=14


### PR DESCRIPTION
Had to enable preview features on Java 14 for maven compiler and maven surefire. 
For local, I had to set java_home of latest java for maven to pick up that version.  

To enable preview features on Heroku, run this command:
`heroku config:set _JAVA_OPTIONS="--enable-preview"`